### PR TITLE
Fixes search

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,26 +26,26 @@ export default function Home() {
     });
   }, []);
 
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const targetValue = e.target.value;
-    setSearchTerm(targetValue);
-
+  useEffect(() => {
     const filteredAdvocates = advocates.filter((advocate) => {
       return (
-        advocate.firstName.includes(targetValue) ||
-        advocate.lastName.includes(targetValue) ||
-        advocate.city.includes(targetValue) ||
-        advocate.degree.includes(targetValue) ||
-        advocate.specialties.includes(targetValue) ||
-        advocate.yearsOfExperience.toString().includes(targetValue)
+        advocate.firstName.includes(searchTerm) ||
+        advocate.lastName.includes(searchTerm) ||
+        advocate.city.includes(searchTerm) ||
+        advocate.degree.includes(searchTerm) ||
+        advocate.specialties.includes(searchTerm) ||
+        advocate.yearsOfExperience.toString().includes(searchTerm)
       );
     });
 
     setFilteredAdvocates(filteredAdvocates);
+  }, [searchTerm, advocates]);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value);
   };
 
   const onClick = () => {
-    setFilteredAdvocates(advocates);
     setSearchTerm("");
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -81,8 +81,14 @@ export default function Home() {
           </tr>
         </thead>
         <tbody>
-          {filteredAdvocates.map((advocate) => {
-            return (
+          {filteredAdvocates.length === 0 && searchTerm ? (
+            <tr>
+              <td colSpan={7} style={{ textAlign: "center" }}>
+                No advocates found for "{searchTerm}"
+              </td>
+            </tr>
+          ) : (
+            filteredAdvocates.map((advocate) => (
               <tr key={`${advocate.firstName}-${advocate.lastName}`}>
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
@@ -96,8 +102,8 @@ export default function Home() {
                 <td>{advocate.yearsOfExperience}</td>
                 <td>{advocate.phoneNumber}</td>
               </tr>
-            );
-          })}
+            ))
+          )}
         </tbody>
       </table>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,7 +64,7 @@ export default function Home() {
           Searching for: <span>{searchTerm}</span>
         </p>
         <input style={{ border: "1px solid black" }} onChange={onChange} value={searchTerm} />
-        <button onClick={onClick}>Reset Search</button>
+        <button onClick={onClick}>Reset</button>
       </div>
       <br />
       <br />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,13 +28,17 @@ export default function Home() {
 
   useEffect(() => {
     const filteredAdvocates = advocates.filter((advocate) => {
+      const withoutCaseIncludes = (source: string, search: string): boolean => {
+        return source.toLowerCase().includes(search.toLowerCase());
+      };
+
       return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.toString().includes(searchTerm)
+        withoutCaseIncludes(advocate.firstName, searchTerm) ||
+        withoutCaseIncludes(advocate.lastName, searchTerm) ||
+        withoutCaseIncludes(advocate.city, searchTerm) ||
+        withoutCaseIncludes(advocate.degree, searchTerm) ||
+        advocate.specialties.some((s) => withoutCaseIncludes(s, searchTerm)) ||
+        withoutCaseIncludes(advocate.yearsOfExperience.toString(), searchTerm)
       );
     });
 


### PR DESCRIPTION
## Summary

There were a few ways search wasn't functioning as expected. This PR aims to fix them.
See: [Before](#before) 

## Changes

- Adds useEffect to handle setFilteredAdvocates
- Updates search to be case insensitive
- Adds zero state to table
- Removes redundant "Search" text from button

## Before

- Results were only showing for text with same case (upper/lower)
- Results weren't updating when expected
- All data was displayed when searchTerm matched no results

## Verification

- [x] Can search lowercase and still see results with uppercase values
- [x] Can search uppercase and still see results with lowercase values
- [x] Verify table updates when `onChange` event happens (read: on each change to input box)
- [x] When no results match search time, `No advocates found for "{searchTerm}"` is displayed
