### PR TITLE
[Fixes] Adds simple styles to Advocates Page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,55 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.main {
+  @apply p-6 bg-gray-100 min-h-screen font-sans;
+}
+
+.page-header {
+  @apply text-2xl sm:text-3xl font-bold text-center text-primary mb-6;
+}
+
+.search-box {
+  @apply bg-white p-4 rounded shadow-md;
+}
+
+.search-header {
+  @apply text-lg font-medium text-gray-700;
+}
+
+.search-subheader {
+  @apply text-sm text-gray-500;
+}
+
+.search-term {
+  @apply font-semibold text-gray-800;
+}
+
+.search-box-controls {
+  @apply flex flex-col sm:flex-row items-center gap-4 mt-4;
+}
+
+.search-input {
+  @apply border border-gray-300 rounded px-4 py-2 w-full focus:outline-none focus:ring-2 focus:ring-primary;
+}
+
+.search-reset-button {
+  @apply bg-primary text-white px-4 py-2 rounded hover:bg-opacity-90 transition;
+}
+
+.advocates-table {
+  @apply w-full table-auto bg-white rounded shadow-md overflow-hidden;
+}
+
+.table-wrapper {
+  @apply mt-6 overflow-x-auto;
+}
+
+.table-header {
+  @apply px-4 py-2 text-left;
+}
+
+.table-cell {
+  @apply border px-4 py-2;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,58 +54,67 @@ export default function Home() {
   };
 
   return (
-    <main style={{ margin: "24px" }}>
-      <h1>Solace Advocates</h1>
-      <br />
-      <br />
-      <div>
-        <p>Search</p>
-        <p>
+    <main className="main">
+      <h1 className="page-header">Solace Advocates</h1>
+      <div className="search-box">
+        <p className="search-header">Search</p>
+        <p className="search-subheader">
           Searching for: <span>{searchTerm}</span>
         </p>
-        <input style={{ border: "1px solid black" }} onChange={onChange} value={searchTerm} />
-        <button onClick={onClick}>Reset</button>
+        <div className="search-box-controls">
+          <input
+            className="search-input"
+            onChange={onChange}
+            placeholder="Search advocates..."
+            value={searchTerm} />
+          <button
+            className="search-reset-button"
+            onClick={onClick}
+          >
+            Reset
+          </button>
+        </div>
       </div>
-      <br />
-      <br />
-      <table>
-        <thead>
-          <tr>
-            <th>First Name</th>
-            <th>Last Name</th>
-            <th>City</th>
-            <th>Degree</th>
-            <th>Specialties</th>
-            <th>Years of Experience</th>
-            <th>Phone Number</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAdvocates.length === 0 && searchTerm ? (
+      <div className="table-wrapper">
+        <table className="advocates-table">
+          <thead className="bg-primary text-white">
             <tr>
-              <td colSpan={7} style={{ textAlign: "center" }}>
-                No advocates found for "{searchTerm}"
-              </td>
+              <th className="table-header">First Name</th>
+              <th className="table-header">Last Name</th>
+              <th className="table-header">City</th>
+              <th className="table-header">Degree</th>
+              <th className="table-header">Specialties</th>
+              <th className="table-header">Years of Experience</th>
+              <th className="table-header">Phone Number</th>
             </tr>
-          ) : (
-            filteredAdvocates.map((advocate) => (
-              <tr key={`${advocate.firstName}-${advocate.lastName}`}>
-                <td>{advocate.firstName}</td>
-                <td>{advocate.lastName}</td>
-                <td>{advocate.city}</td>
-                <td>{advocate.degree}</td>
-                <td>
-                  {advocate.specialties.map((s) => (
-                    <div key={s}>{s}</div>
-                  ))}
+          </thead>
+          <tbody>
+            {filteredAdvocates.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="text-center text-gray-500 py-4">
+                  No advocates found.
                 </td>
-                <td>{advocate.yearsOfExperience}</td>
-                <td>{advocate.phoneNumber}</td>
               </tr>
-            ))
-          )}
-        </tbody>
-      </table>
+            ) : (
+              filteredAdvocates.map((advocate) => (
+                <tr key={`${advocate.firstName}-${advocate.lastName}`} className="hover:bg-gray-100">
+                  <td className="table-cell">{advocate.firstName}</td>
+                  <td className="table-cell">{advocate.lastName}</td>
+                  <td className="table-cell">{advocate.city}</td>
+                  <td className="table-cell">{advocate.degree}</td>
+                  <td className="table-cell">
+                    {advocate.specialties.map((s) => (
+                      <div key={s}>{s}</div>
+                    ))}
+                  </td>
+                  <td className="table-cell">{advocate.yearsOfExperience}</td>
+                  <td className="table-cell">{advocate.phoneNumber}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
     </main>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,12 @@ const config: Config = {
         "gradient-conic":
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
+      fontFamily: {
+        sans: ['Helvetica', 'sans-serif'],
+      },
+      colors: {
+        primary: "#285E50",
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

Original Advocates page had no styling. This PR adds simple table and page styling

## Changes

- Updates `globals.css` to have classes for use on `page.tsx`
- Updates `tailwind.config.ts` to have default font family and primary color
- Uses classes on `page.tsx` for basic styling

## Before

- Page had no styling

<img width="1169" alt="Screenshot 2025-05-06 at 4 23 02 PM" src="https://github.com/user-attachments/assets/77447a7e-9f4b-485f-82b5-1c297bc6c7e7" />


## Verification

- [x] Verify page still has same functionality as before styling (search, reset, pagination)
- [x] Verify page has simple page, table, and pagination styles
- [x] Verify page is still useable in mobile view
 
<img width="1426" alt="Screenshot 2025-05-06 at 4 23 42 PM" src="https://github.com/user-attachments/assets/cf40cff1-ef14-4c97-b11a-7c5f58ce1409" />
